### PR TITLE
Fix hardcoded windows paths for compatability with Linux & Mac

### DIFF
--- a/src/main/java/com/exchangelogger/ExchangeLoggerPlugin.java
+++ b/src/main/java/com/exchangelogger/ExchangeLoggerPlugin.java
@@ -50,8 +50,8 @@ public class ExchangeLoggerPlugin extends Plugin
 	@Inject
 	private ExchangeLoggerConfig config;
 
-	private final String dirName = "\\exchange-logger";
-	private final String logName = "\\exchange.log";
+	private final String dirName = File.separator + "exchange-logger";
+	private final String logName = File.separator + "exchange.log";
 
 	public static final String CONFIG_GROUP = "exchangelogger";
 	private ExchangeLoggerFormat format;


### PR DESCRIPTION
Simply replaced the hardcoded `\\` with `File.separator` for the log file/directory. At the moment, on linux the current version doesn't make the log files correctly.

To be candid, I did NOT test this in-game on runelite. It compiles but I am not 100% sure this actually works correctly as I do not have a dev environment setup for runelite development right now.

Closes #1